### PR TITLE
Prepare to Rector next 2.0 with PHPStan 2 and PHPParser 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "rector/rector": "^1.0"
+        "rector/rector": "dev-main as 1.2.10"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",
         "moneyphp/money": "^3.2|^4.0.1",
         "phparkitect/phparkitect": "^0.2.32",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.7.2",
-        "phpstan/phpstan-strict-rules": "^1.1",
+        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^9.5",
         "symfony/dependency-injection": "^5.4|^6.0",
         "symplify/easy-coding-standard": "^11.0"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "rector/rector": "dev-main as 1.2.10"
+        "rector/rector": "~2.0.0"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/src/Rule/MultiplyAndDivideByStringRector.php
+++ b/src/Rule/MultiplyAndDivideByStringRector.php
@@ -14,7 +14,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Scalar\DNumber;
+use PhpParser\Node\Scalar\Float_;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\MutatingScope;
 use PHPStan\Type\ObjectType;
@@ -69,7 +69,7 @@ final class MultiplyAndDivideByStringRector extends AbstractRector implements Co
         $firstArgValue = $firstArg->value;
 
         // Refactor passing float as an explicit argument
-        if ($firstArgValue instanceof DNumber) {
+        if ($firstArgValue instanceof Float_) {
             $firstArg->value = new String_((string)$firstArgValue->value);
 
             return $node;


### PR DESCRIPTION
Rector is upgrading to PHPStan 2 and PHPParser 5 at PR:

- https://github.com/rectorphp/rector-src/pull/6431

this PR upgrade for compatiblity syntax.